### PR TITLE
Add CircleCI to publish docker image to GCR

### DIFF
--- a/.circleci/config.yaml
+++ b/.circleci/config.yaml
@@ -1,0 +1,16 @@
+# Reference: https://github.com/mozilla/pensieve/blob/master/.circleci/config.yml
+version: 2.1
+
+# See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
+orbs:
+  gcp-gcr: circleci/gcp-gcr@0.6.1
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - gcp-gcr/build-and-push-image:
+          image: ds_283_prod
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
For this to work, the following pieces need to be run from [this cookbook](https://docs.telemetry.mozilla.org/cookbooks/deploying-containers.html#on-circleci). In particular, the following variables will need to be set in CircleCI.

* GOOGLE_PROJECT_ID
* GOOGLE_COMPUTE_ZONE
* GCLOUD_SERVICE_KEY