### PR TITLE
Use circleci classic image on machine host

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,12 @@ version: 2.1
 jobs:
   # command for building an image with docker caching layer enabled
   build-and-push:
-    executor: gcp-gcr/default
+    # https://github.com/CircleCI-Public/gcp-gcr-orb/blob/master/src/executors/default.yml
+    machine:
+      image: circleci/classic:latest
+      docker_layer_caching: true
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
       - gcp-gcr/gcr-auth
       - gcp-gcr/build-image:
           image: ds_283_prod


### PR DESCRIPTION
This uses the machine executor with `docker_caching_layer` enabled. #3 relied on the executor that came prepackaged with the orb for gcp-gcr, which is actually a machine executor. 