### PR TITLE
Application-default credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rocker/verse:3.5.0
 RUN mkdir /tmp/output/
-RUN R -e "options(repos =  list(CRAN = 'https://cran.microsoft.com/snapshot/2020-04-10/')); \
+RUN R -e "options(repos =  list(CRAN = 'https://cran.microsoft.com/snapshot/2020-05-07/')); \
           pkgs <- c('vegawidget','parsedate','logging', 'Hmisc', 'ggplot2','glue','DBI','bigrquery','gargle','data.table','knitr','rmarkdown'); \
           install.packages(pkgs,dep=TRUE);"
 

--- a/query.R
+++ b/query.R
@@ -36,7 +36,7 @@ bq <- function(
                ){
     if(is.null(path) || path==""){
         message("Using Email Auth")
-        bq_auth(email='sguha@mozilla.com' ,use_oob =TRUE )
+        bq_auth(use_oob=TRUE)
     } else {
         message("Using Service Credentials")
         bq_auth(path=path)


### PR DESCRIPTION
Allow fallback to unnamed ADCs and pull in a Gargle fix for ADCs.

Closes #8.